### PR TITLE
Rename language id

### DIFF
--- a/src/main/java/io/protostuff/jetbrains/plugin/ProtoFileType.java
+++ b/src/main/java/io/protostuff/jetbrains/plugin/ProtoFileType.java
@@ -19,7 +19,7 @@ public class ProtoFileType extends LanguageFileType {
     @NotNull
     @Override
     public String getName() {
-        return "Protobuf";
+        return "PROTO";
     }
 
     @NotNull

--- a/src/main/java/io/protostuff/jetbrains/plugin/ProtoLanguage.java
+++ b/src/main/java/io/protostuff/jetbrains/plugin/ProtoLanguage.java
@@ -1,11 +1,24 @@
 package io.protostuff.jetbrains.plugin;
 
 import com.intellij.lang.Language;
+import org.jetbrains.annotations.NotNull;
 
 public class ProtoLanguage extends Language {
     public static final ProtoLanguage INSTANCE = new ProtoLanguage();
 
     private ProtoLanguage() {
-        super("Protobuf");
+        super("PROTO");
     }
+
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "Protobuf";
+    }
+
+    @Override
+    public boolean isCaseSensitive() {
+        return true;
+    }
+
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,11 +40,11 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <fileTypeFactory implementation="io.protostuff.jetbrains.plugin.ProtoFileTypeFactory"/>
-        <lang.parserDefinition language="Protobuf"
+        <lang.parserDefinition language="PROTO"
                                implementationClass="io.protostuff.jetbrains.plugin.ProtoParserDefinition"/>
-        <lang.syntaxHighlighterFactory language="Protobuf"
+        <lang.syntaxHighlighterFactory language="PROTO"
                                        implementationClass="io.protostuff.jetbrains.plugin.ProtoSyntaxHighlighterFactory"/>
-        <annotator language="Protobuf"
+        <annotator language="PROTO"
                    implementationClass="io.protostuff.jetbrains.plugin.ProtoSyntaxKeywordsAnnotator"/>
 
         <colorSettingsPage implementation="io.protostuff.jetbrains.plugin.ProtoColorSettingsPage"/>


### PR DESCRIPTION
Rename language id - from `protobuf` to `proto` so that it can be injected in other editors using more common name "proto".